### PR TITLE
Fix TOC display issues

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/container/Container.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/container/Container.kt
@@ -57,6 +57,7 @@ interface EpubContainer : Container {
 
     fun xmlDocumentForFile(relativePath: String): XmlParser
     fun xmlDocumentForResource(link: Link?): XmlParser
+    fun xmlAsByteArray(link: Link?): ByteArray
     fun scanForDrm(): Drm?
 }
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/container/ContainerEpub.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/container/ContainerEpub.kt
@@ -28,6 +28,14 @@ class ContainerEpub : EpubContainer, ZipArchiveContainer {
         return document
     }
 
+    override fun xmlAsByteArray(link: Link?): ByteArray {
+        var pathFile = link?.href ?: throw Exception("Missing Link : ${link?.title}")
+        if (pathFile.first() == '/')
+            pathFile = pathFile.substring(1)
+
+        return data(pathFile)
+    }
+
     override fun xmlDocumentForResource(link: Link?): XmlParser {
         var pathFile = link?.href ?: throw Exception("Missing Link : ${link?.title}")
         if (pathFile.first() == '/')

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/container/ContainerEpubDirectory.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/container/ContainerEpubDirectory.kt
@@ -29,6 +29,14 @@ class ContainerEpubDirectory : EpubContainer, DirectoryContainer {
         return document
     }
 
+    override fun xmlAsByteArray(link: Link?): ByteArray {
+        var pathFile = link?.href ?: throw Exception("Missing Link : ${link?.title}")
+        if (pathFile.first() == '/')
+            pathFile = pathFile.substring(1)
+
+        return data(pathFile)
+    }
+
     override fun xmlDocumentForResource(link: Link?): XmlParser {
         var pathFile = link?.href ?: throw Exception("missing Link : ${link?.title}")
         if (pathFile.first() == '/')

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
@@ -62,8 +62,8 @@ class EpubParser : PublicationParser {
 
         fillEncryptionProfile(publication, drm)
 //            parseMediaOverlay(fetcher, publication)
-        parseNavigationDocument(container as EpubContainer, publication)
-        parseNcxDocument(container, publication)
+//        parseNavigationDocument(container as EpubContainer, publication)
+//        parseNcxDocument(container, publication)
 
         return Pair(container, publication)
     }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
@@ -155,14 +155,23 @@ class EpubParser : PublicationParser {
 
     private fun parseNavigationDocument(container: EpubContainer, publication: Publication) {
         val navLink = publication.linkWithRel("contents") ?: return
+
         val navDocument = try {
             container.xmlDocumentForResource(navLink)
         } catch (e: Exception) {
             Log.e("Error", "Navigation parsing", e)
             return
         }
+
+        val navByteArray = try {
+            container.xmlAsByteArray(navLink)
+        } catch (e: Exception) {
+            Log.e("Error", "Navigation parsing", e)
+            return
+        }
+
         ndp.navigationDocumentPath = navLink.href ?: return
-        publication.tableOfContents.plusAssign(ndp.tableOfContent(navDocument))
+        publication.tableOfContents = ndp.tableOfContent(navByteArray)
         publication.landmarks.plusAssign(ndp.landmarks(navDocument))
         publication.listOfAudioFiles.plusAssign(ndp.listOfAudiofiles(navDocument))
         publication.listOfIllustrations.plusAssign(ndp.listOfIllustrations(navDocument))

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
@@ -150,7 +150,6 @@ class EpubParser : PublicationParser {
             encp.parseEncryptionProperties(encryptedDataElement, encryption)
             encp.add(encryption, publication, encryptedDataElement)
         }
-
     }
 
     private fun parseNavigationDocument(container: EpubContainer, publication: Publication) {
@@ -171,7 +170,7 @@ class EpubParser : PublicationParser {
         }
 
         ndp.navigationDocumentPath = navLink.href ?: return
-        publication.tableOfContents = ndp.tableOfContent(navByteArray)
+        publication.tableOfContents.plusAssign(ndp.tableOfContent(navByteArray))
         publication.landmarks.plusAssign(ndp.landmarks(navDocument))
         publication.listOfAudioFiles.plusAssign(ndp.listOfAudiofiles(navDocument))
         publication.listOfIllustrations.plusAssign(ndp.listOfIllustrations(navDocument))

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/EpubParser.kt
@@ -22,7 +22,6 @@ import org.readium.r2.streamer.parser.epub.EncryptionParser
 import org.readium.r2.streamer.parser.epub.NCXParser
 import org.readium.r2.streamer.parser.epub.NavigationDocumentParser
 import org.readium.r2.streamer.parser.epub.OPFParser
-import org.zeroturnaround.zip.ZipUtil
 import java.io.File
 
 // Some constants useful to parse an Epub document
@@ -56,14 +55,9 @@ class EpubParser : PublicationParser {
         return container
     }
 
-    fun parseRemainingResource(container: Container, publication: Publication, drm: Drm?): Pair<Container, Publication> {
-
+    fun parseEncryption(container: Container, publication: Publication, drm: Drm?): Pair<Container, Publication> {
         container.drm = drm
-
         fillEncryptionProfile(publication, drm)
-//            parseMediaOverlay(fetcher, publication)
-//        parseNavigationDocument(container as EpubContainer, publication)
-//        parseNcxDocument(container, publication)
 
         return Pair(container, publication)
     }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
@@ -33,14 +33,12 @@ class NavigationDocumentParser {
         val nodes = evaluateXpath(xpath, document)
 
         for (i in 0 until nodes.length) {
-            val link = Link()
-
             nodes.item(i).attributes.getNamedItem("href")?.let {
+                val link = Link()
                 link.href = it.nodeValue
                 link.title = nodes.item(i).textContent
                 tableOfContents.add(link)
             }
-
         }
 
         return tableOfContents

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
@@ -13,12 +13,37 @@ import org.readium.r2.shared.Link
 import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.parser.xml.Node
 import org.readium.r2.streamer.parser.normalize
+import org.w3c.dom.NodeList
+import java.io.InputStream
+import javax.xml.XMLConstants
+import javax.xml.namespace.NamespaceContext
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
 
 class NavigationDocumentParser {
 
     var navigationDocumentPath: String = ""
 
-    fun tableOfContent(document: XmlParser) = nodeArray(document, "toc")
+    fun tableOfContent(xml: ByteArray) : MutableList<Link> {
+        val tableOfContents = mutableListOf<Link>()
+        val document = xml.inputStream()
+
+        val xpath = "/xhtml:html/xhtml:body/xhtml:nav[@epub:type='toc']//xhtml:a" + "|/xhtml:html/xhtml:body/xhtml:nav[@epub:type='toc']//xhtml:span"
+        val nodes = evaluateXpath(xpath, document)
+
+        for (i in 0 until nodes.length) {
+            val link = Link()
+
+            link.href = nodes.item(i).attributes.getNamedItem("href")?.nodeValue
+            link.title = nodes.item(i).textContent
+
+            tableOfContents.add(link)
+        }
+
+        return tableOfContents
+    }
+
     fun pageList(document: XmlParser) = nodeArray(document, "page-list")
     fun landmarks(document: XmlParser) = nodeArray(document, "landmarks")
     fun listOfIllustrations(document: XmlParser) = nodeArray(document, "loi")
@@ -61,4 +86,39 @@ class NavigationDocumentParser {
         return newLiNode
     }
 
+
+    private fun evaluateXpath(expression: String, doc: InputStream): NodeList {
+
+        val dbFactory = DocumentBuilderFactory.newInstance()
+        dbFactory.isNamespaceAware = true
+        val docBuilder  = dbFactory.newDocumentBuilder()
+
+        val document = docBuilder.parse(doc)
+
+        val xPath = XPathFactory.newInstance().newXPath()
+        xPath.namespaceContext = NameSpaceResolver()
+
+        return xPath.evaluate(expression, document, XPathConstants.NODESET) as NodeList
+    }
+
 }
+
+class NameSpaceResolver : NamespaceContext {
+    override fun getNamespaceURI(p0: String?): String {
+        when (p0) {
+            null -> throw IllegalArgumentException("No prefix provided!")
+            "epub" -> return "http://www.idpf.org/2007/ops"
+            "xhtml" -> return "http://www.w3.org/1999/xhtml"
+            else -> return XMLConstants.DEFAULT_NS_PREFIX
+        }
+    }
+
+    override fun getPrefix(p0: String?): String? {
+        return null
+    }
+
+    override fun getPrefixes(p0: String?): MutableIterator<Any?>? {
+        return null
+    }
+}
+

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
@@ -54,7 +54,7 @@ class NavigationDocumentParser {
     private fun nodeLi(element: Node): Link {
         val newLiNode = Link()
         val aNode = element.getFirst("a")!!
-        val title = (aNode.getFirst("span"))?.name ?: aNode.text ?: aNode.name
+        val title = (aNode.getFirst("span"))?.text ?: aNode.text ?: aNode.name
         newLiNode.href = normalize(navigationDocumentPath, aNode.attributes["href"])
         newLiNode.title = title
         element.getFirst("ol")?.let { newLiNode.children.add(nodeOl(it)) }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
@@ -35,10 +35,12 @@ class NavigationDocumentParser {
         for (i in 0 until nodes.length) {
             val link = Link()
 
-            link.href = nodes.item(i).attributes.getNamedItem("href")?.nodeValue
-            link.title = nodes.item(i).textContent
+            nodes.item(i).attributes.getNamedItem("href")?.let {
+                link.href = it.nodeValue
+                link.title = nodes.item(i).textContent
+                tableOfContents.add(link)
+            }
 
-            tableOfContents.add(link)
         }
 
         return tableOfContents

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParser.kt
@@ -86,11 +86,11 @@ class NavigationDocumentParser {
         return newLiNode
     }
 
-
     private fun evaluateXpath(expression: String, doc: InputStream): NodeList {
 
         val dbFactory = DocumentBuilderFactory.newInstance()
         dbFactory.isNamespaceAware = true
+        
         val docBuilder  = dbFactory.newDocumentBuilder()
 
         val document = docBuilder.parse(doc)
@@ -100,7 +100,6 @@ class NavigationDocumentParser {
 
         return xPath.evaluate(expression, document, XPathConstants.NODESET) as NodeList
     }
-
 }
 
 class NameSpaceResolver : NamespaceContext {


### PR DESCRIPTION
Based on what is done on iOS
fixes https://github.com/readium/r2-testapp-kotlin/issues/124

When displaying the TOC, what is left to do is to indent the TOC elements according to their level