### PR TITLE
Only bind the HTTP server to localhost interface.

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
@@ -23,7 +23,7 @@ import java.util.*
 
 class Server(port: Int) : AbstractServer(port)
 
-abstract class AbstractServer(private var port: Int) : RouterNanoHTTPD(port) {
+abstract class AbstractServer(private var port: Int) : RouterNanoHTTPD("localhost", port) {
 
     //    private val SEARCH_QUERY_HANDLE = "/search"
     private val MANIFEST_HANDLE = "/manifest"


### PR DESCRIPTION
Currently, the HTTP server binds to all known network interfaces. This makes it possible for remote clients on the same local network to directly connect to the server, possibly opening for various remote attacks.

By binding the server only to the localhost interface, we reduce the risk of running this server.

See https://github.com/readium/r2-testapp-kotlin/issues/144 for additional details.