### PR TITLE
revert jsoup to version 1.10.3 (API 23 compatibility)

### DIFF
--- a/r2-streamer/build.gradle
+++ b/r2-streamer/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-core:$JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-databind:$JACKSON_VERSION"
-    implementation 'org.jsoup:jsoup:1.11.2'
+    implementation 'org.jsoup:jsoup:1.10.3'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'


### PR DESCRIPTION
On Android API 23 (6.0), Jsoup 1.11.2 has a bad behaviour. It causes trouble while implementing apps using it (like the ScreenReader feature in the testapp).

Reverting it to version 1.10.3 fixes these issues.