### PR TITLE
Fallback to epub 2 rules for title's sorting key and cover in epub 3.x parsing

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
@@ -80,7 +80,7 @@ internal class MetadataParser(private val epubVersion: Double, private val prefi
     }
 
     private fun parseMetaElement(element: ElementNode): MetadataItem? {
-        return if (epubVersion < 3.0) {
+        return if (element.getAttr("property") == null) {
             val name = element.getAttr("name")
                 ?: return null
             val content = element.getAttr("content")
@@ -223,7 +223,7 @@ internal class PubMetadataAdapter(
 
         localizedTitle =  mainTitle?.value ?: LocalizedString(fallbackTitle)
         localizedSubtitle = titles.filter { it.type == "subtitle" }.sortedBy(Title::displaySeq).firstOrNull()?.value
-        sortAs = if (epubVersion < 3.0) firstValue("calibre:title_sort") else mainTitle?.fileAs
+        sortAs = mainTitle?.fileAs ?: firstValue("calibre:title_sort")
     }
 
     val belongsToSeries: List<Collection>

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PublicationFactory.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PublicationFactory.kt
@@ -148,10 +148,8 @@ internal class PublicationFactory(
             properties.putAll(parseItemrefProperties(itemref.properties))
         }
 
-        if (epubVersion < 3.0) {
-            val coverId = pubMetadata.cover
-            if (coverId != null && item.id == coverId) rels.add("cover")
-        }
+        val coverId = pubMetadata.cover
+        if (coverId != null && item.id == coverId) rels.add("cover")
 
         encryptionData[item.href]?.let {
             properties["encrypted"] = it.toJSON().toMap()

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -350,6 +350,7 @@ class MetadataMiscTest {
         )
         assertThat(parsePackageDocument("package/cover-epub2.opf").coverLink).isEqualTo(expected)
         assertThat(parsePackageDocument("package/cover-epub3.opf").coverLink).isEqualTo(expected)
+        assertThat(parsePackageDocument("package/cover-mix.opf").coverLink).isEqualTo(expected)
     }
 
     @Test(timeout = PARSE_PUB_TIMEOUT)

--- a/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/cover-mix.opf
+++ b/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/cover-mix.opf
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Alice's Adventures in Wonderland</dc:title>
+    <meta name="cover" content="cover" />
+  </metadata>
+  <manifest>
+    <item id="cover" href="cover.jpg" media-type="image/jpeg"/>
+    <item id="titlepage" href="titlepage.xhtml"/>
+  </manifest>
+  <spine>
+    <itemref idref="titlepage"/>
+  </spine>
+</package>


### PR DESCRIPTION
Fix #94