### PR TITLE
Simplify metadata parsing by aligning with new specifications

### DIFF
--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -80,6 +80,7 @@ class ContributorParsingTest {
     fun `Only the first role is considered (epub3 only)`() {
         val contributor = Contributor(localizedName = LocalizedString("Cameleon"))
         assertThat(epub3Metadata.authors).contains(contributor)
+        assertThat(epub3Metadata.publishers).doesNotContain(contributor)
     }
 
     @Test

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -29,20 +29,14 @@ class ContributorParsingTest {
 
     @Test
     fun `dc_creator is by default an author`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Author 1"),
-            roles = setOf("aut")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Author 1"))
         assertThat(epub2Metadata.authors).contains(contributor)
         assertThat(epub3Metadata.authors).contains(contributor)
     }
 
     @Test
-    fun `dc_publisher is by default a publisher`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Publisher 1"),
-            roles = setOf("pbl")
-        )
+    fun `dc_publisher is a publisher`() {
+        val contributor = Contributor(localizedName = LocalizedString("Publisher 1"))
         assertThat(epub2Metadata.publishers).contains(contributor)
         assertThat(epub3Metadata.publishers).contains(contributor)
     }
@@ -84,55 +78,40 @@ class ContributorParsingTest {
 
     @Test
     fun `Only the first role is considered (epub3 only)`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Cameleon"),
-            roles = setOf("aut")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Cameleon"))
         assertThat(epub3Metadata.authors).contains(contributor)
     }
 
     @Test
     fun `Media Overlays narrators are rightly parsed (epub3 only)`() {
-        val contributor = Contributor(localizedName = LocalizedString("Media Overlays Narrator"), roles = setOf("nrt"))
+        val contributor = Contributor(localizedName = LocalizedString("Media Overlays Narrator"))
         assertThat(epub3Metadata.narrators).contains(contributor)
     }
 
     @Test
     fun `Author is rightly parsed`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Author 2"),
-            roles = setOf("aut")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Author 2"))
         assertThat(epub2Metadata.authors).contains(contributor)
         assertThat(epub3Metadata.authors).contains(contributor)
     }
 
     @Test
     fun `Publisher is rightly parsed`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Publisher 2"),
-            roles = setOf("pbl")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Publisher 2")        )
         assertThat(epub2Metadata.publishers).contains(contributor)
         assertThat(epub3Metadata.publishers).contains(contributor)
     }
 
     @Test
     fun `Translator is rightly parsed`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Translator"),
-            roles = setOf("trl")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Translator"))
         assertThat(epub2Metadata.translators).contains(contributor)
         assertThat(epub3Metadata.translators).contains(contributor)
     }
 
     @Test
     fun `Artist is rightly parsed`() {
-        val contributor = Contributor(
-            localizedName = LocalizedString("Artist"),
-            roles = setOf("art")
-        )
+        val contributor = Contributor(localizedName = LocalizedString("Artist"))
         assertThat(epub2Metadata.artists).contains(contributor)
         assertThat(epub3Metadata.artists).contains(contributor)
     }
@@ -141,7 +120,7 @@ class ContributorParsingTest {
     fun `Illustrator is rightly parsed`() {
         val contributor = Contributor(
             localizedName = LocalizedString("Illustrator"),
-            roles = setOf("ill")
+            roles = emptySet()
         )
         assertThat(epub2Metadata.illustrators).contains(contributor)
         assertThat(epub3Metadata.illustrators).contains(contributor)
@@ -151,7 +130,7 @@ class ContributorParsingTest {
     fun `Colorist is rightly parsed`() {
         val contributor = Contributor(
             localizedName = LocalizedString("Colorist"),
-            roles = setOf("clr")
+            roles = emptySet()
         )
         assertThat(epub2Metadata.colorists).contains(contributor)
         assertThat(epub3Metadata.colorists).contains(contributor)
@@ -161,7 +140,7 @@ class ContributorParsingTest {
     fun `Narrator is rightly parsed`() {
         val contributor = Contributor(
             localizedName = LocalizedString("Narrator"),
-            roles = setOf("nrt")
+            roles = emptySet()
         )
         assertThat(epub2Metadata.narrators).contains(contributor)
         assertThat(epub3Metadata.narrators).contains(contributor)

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -200,14 +200,14 @@ class TitleTest {
         assertThat(epub2Metadata.localizedTitle).isEqualTo(
             LocalizedString.fromStrings(
                 mapOf(
-                    "en" to "Alice's Adventures in Wonderland"
+                    null to "Alice's Adventures in Wonderland"
                 )
             )
         )
         assertThat(epub3Metadata.localizedTitle).isEqualTo(
             LocalizedString.fromStrings(
                 mapOf(
-                    "en" to "Alice's Adventures in Wonderland",
+                    null to "Alice's Adventures in Wonderland",
                     "fr" to "Les Aventures d'Alice au pays des merveilles"
                 )
             )
@@ -241,7 +241,7 @@ class TitleTest {
     @Test
     fun `The selected subtitle has the lowest display-seq property (epub3 only)`() {
         val metadata = parsePackageDocument("package/title-multiple-subtitles.opf").metadata
-        assertThat(metadata.localizedSubtitle).isEqualTo(LocalizedString.fromStrings(mapOf("en" to "Subtitle 2")))
+        assertThat(metadata.localizedSubtitle).isEqualTo(LocalizedString.fromStrings(mapOf(null to "Subtitle 2")))
     }
 }
 

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -55,13 +55,6 @@ class ContributorParsingTest {
     }
 
     @Test
-    fun `Refined roles override tag names`() {
-        val contributor = Contributor(localizedName = LocalizedString("Author 2"), roles = setOf("aut"))
-        assertThat(epub2Metadata.authors).contains(contributor)
-        assertThat(epub3Metadata.authors).contains(contributor)
-    }
-
-    @Test
     fun `Unknown roles are ignored`() {
         val contributor = Contributor(localizedName = LocalizedString("Contributor 2"), roles = setOf("unknown"))
         assertThat(epub2Metadata.contributors).contains(contributor)
@@ -90,13 +83,12 @@ class ContributorParsingTest {
     }
 
     @Test
-    fun `Multiple roles are all parsed (epub3 only)`() {
+    fun `Only the first role is considered (epub3 only)`() {
         val contributor = Contributor(
             localizedName = LocalizedString("Cameleon"),
-            roles = setOf("aut", "pbl")
+            roles = setOf("aut")
         )
         assertThat(epub3Metadata.authors).contains(contributor)
-        assertThat(epub3Metadata.publishers).contains(contributor)
     }
 
     @Test
@@ -108,7 +100,7 @@ class ContributorParsingTest {
     @Test
     fun `Author is rightly parsed`() {
         val contributor = Contributor(
-            localizedName = LocalizedString("Author 3"),
+            localizedName = LocalizedString("Author 2"),
             roles = setOf("aut")
         )
         assertThat(epub2Metadata.authors).contains(contributor)
@@ -177,7 +169,7 @@ class ContributorParsingTest {
 
     @Test
     fun `No more contributor than needed`() {
-        assertThat(epub2Metadata.authors).size().isEqualTo(3)
+        assertThat(epub2Metadata.authors).size().isEqualTo(2)
         assertThat(epub2Metadata.publishers).size().isEqualTo(2)
         assertThat(epub2Metadata.translators).size().isEqualTo(1)
         assertThat(epub2Metadata.editors).size().isEqualTo(1)
@@ -187,8 +179,8 @@ class ContributorParsingTest {
         assertThat(epub2Metadata.narrators).size().isEqualTo(1)
         assertThat(epub2Metadata.contributors).size().isEqualTo(3)
 
-        assertThat(epub3Metadata.authors).size().isEqualTo(4)
-        assertThat(epub3Metadata.publishers).size().isEqualTo(3)
+        assertThat(epub3Metadata.authors).size().isEqualTo(3)
+        assertThat(epub3Metadata.publishers).size().isEqualTo(2)
         assertThat(epub3Metadata.translators).size().isEqualTo(1)
         assertThat(epub3Metadata.editors).size().isEqualTo(1)
         assertThat(epub3Metadata.artists).size().isEqualTo(1)

--- a/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/contributors-epub2.opf
+++ b/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/contributors-epub2.opf
@@ -10,15 +10,12 @@
     <!-- dc:contributor is by default a Contributor -->
     <dc:contributor>Contributor 1</dc:contributor>
     
-    <!-- Refined roles override tag names, so Author 2 is not considered a Publisher -->
-    <dc:publisher id="author-2" opf:role="aut">Author 2</dc:publisher>
-     <!-- Unknown role are ignored-->
     <dc:contributor id="unknown" opf:role="unknown">Contributor 2</dc:contributor> 
     <!-- file-as attribute is parsed -->
     <dc:contributor opf:file-as="Sorting Key">Contributor 3</dc:contributor>
     
     <!-- Various roles -->
-    <dc:contributor id="author-3" opf:role="aut">Author 3</dc:contributor>
+    <dc:contributor id="author-2" opf:role="aut">Author 2</dc:contributor>
     <dc:contributor id="publisher" opf:role="pbl">Publisher 2</dc:contributor> 
     <dc:contributor id="translator" opf:role="trl">Translator</dc:contributor> 
     <dc:contributor id="editor" opf:role="edt">Editor</dc:contributor> 

--- a/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/contributors-epub3.opf
+++ b/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/contributors-epub3.opf
@@ -10,9 +10,6 @@
     <!-- dc:contributor is by default a Contributor -->
     <dc:contributor>Contributor 1</dc:contributor>
     
-    <!-- Refined roles override tag names, so Author 2 is not considered a Publisher -->
-    <dc:publisher id="author-2">Author 2</dc:publisher>
-    <meta refines="#author-2" property="role">aut</meta>
     <!-- Unknown roles are ignored -->
     <dc:contributor id="unknown">Contributor 2</dc:contributor> 
     <meta refines="#unknown" property="role">unknown</meta>
@@ -22,17 +19,19 @@
     
      <!-- Localized contributor -->
     <dc:contributor id="localized">Contributor 4</dc:contributor> 
-    <meta refines="#localized" property="alternate-script" xml:lang="fr">Contributeur 4 en français</meta> 
-    <!-- Contributor with multiple roles -->
+    <meta refines="#localized" property="alternate-script" xml:lang="fr">Contributeur 4 en français</meta>
+    
+    <!-- Only the first role is used -->
     <dc:contributor id="cameleon">Cameleon</dc:contributor> 
     <meta refines="#cameleon" property="role">aut</meta>
     <meta refines="#cameleon" property="role">pbl</meta>
+    
     <!-- Media Overlays narrator -->
     <meta property="media:narrator">Media Overlays Narrator</meta>
 
     <!-- Various roles -->
-    <dc:contributor id="author-3">Author 3</dc:contributor>
-    <meta refines="#author-3" property="role">aut</meta>
+    <dc:contributor id="author-2">Author 2</dc:contributor>
+    <meta refines="#author-2" property="role">aut</meta>
     
     <dc:contributor id="publisher">Publisher 2</dc:contributor> 
     <meta refines="#publisher" property="role">pbl</meta>


### PR DESCRIPTION
Use only the first contributor's role (https://github.com/readium/architecture/issues/126)
Always map `dc:publisher` to publisher (https://github.com/readium/architecture/issues/126)
Remove fallback to `dc:language` for metadata language (https://github.com/readium/webpub-manifest/issues/52)
Use `calibre:series` in Epub 3 when 'belongs-to-series' is missing to align with cover and sortAs processing)