### PR TITLE
Fix multiple values of one property in otherMetadata

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Constants.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Constants.kt
@@ -49,7 +49,7 @@ internal object Vocabularies {
     const val TYPE = "http://idpf.org/epub/vocab/structure/#" // this is a guessed value
 
     const val DCTERMS = "http://purl.org/dc/terms/"
-    const val ALLY = "http://www.idpf.org/epub/vocab/package/a11y/#"
+    const val A11Y = "http://www.idpf.org/epub/vocab/package/a11y/#"
     const val MARC = "http://id.loc.gov/vocabulary/"
     const val ONIX = "http://www.editeur.org/ONIX/book/codelists/current.html#"
     const val SCHEMA = "http://schema.org/"

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
@@ -364,9 +364,15 @@ internal class PubMetadataAdapter(
         val rendition = listOf("flow", "spread", "orientation", "layout").map { Vocabularies.RENDITION + it }
         val usedProperties: List<String> = dcterms + media + rendition
 
-        val otherMap: MutableMap<String, Any> = mutableMapOf()
-        val others = items.filterKeys { it !in usedProperties }.values.flatten()
-        others.forEach { otherMap[it.property] = it.toMap() }
+        val otherMap = items
+            .filterKeys { it !in usedProperties }
+            .mapValues {
+                val values = it.value.map(MetadataItem::toMap)
+                when(values.size) {
+                    1 -> values[0]
+                    else -> values
+                }
+            }
         otherMetadata = otherMap + Pair("presentation", presentation.toJSON().toMap())
     }
 }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/Metadata.kt
@@ -81,11 +81,13 @@ internal class MetadataParser(private val epubVersion: Double, private val prefi
 
     private fun parseMetaElement(element: ElementNode): MetadataItem? {
         return if (element.getAttr("property") == null) {
-            val name = element.getAttr("name")
+            val name = element.getAttr("name")?.trim()?.ifEmpty { null }
                 ?: return null
-            val content = element.getAttr("content")
+            val content = element.getAttr("content")?.trim()?.ifEmpty { null }
                 ?: return null
-            MetadataItem(name, content, element.lang, null, null, element.id)
+            val resolvedName = resolveProperty(name, prefixMap)
+                ?: return null
+            MetadataItem(resolvedName, content, element.lang, null, null, element.id)
         } else {
             val propName = element.getAttr("property")?.trim()?.ifEmpty { null }
                 ?: return null

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
@@ -15,7 +15,7 @@ internal val PACKAGE_RESERVED_PREFIXES = mapOf(
     "dcterms" to Vocabularies.DCTERMS,
     "media" to Vocabularies.MEDIA,
     "rendition" to Vocabularies.RENDITION,
-    "ally" to Vocabularies.ALLY,
+    "a11y" to Vocabularies.A11Y,
     "marc" to Vocabularies.MARC,
     "onix" to Vocabularies.ONIX,
     "schema" to Vocabularies.SCHEMA,

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/PropertyDataType.kt
@@ -38,17 +38,14 @@ internal enum class DEFAULT_VOCAB(val iri: String) {
 internal fun resolveProperty(
     property: String, prefixMap: Map<String, String>,
     defaultVocab: DEFAULT_VOCAB? = null
-): String? {
+): String {
     val splitted = property.split(":", limit = 2).filterNot(String::isEmpty)
-    return if (splitted.size == 1) {
-        if (defaultVocab == null) Timber.d("Missing prefix in property $property, no default vocabulary available")
-        defaultVocab?.iri?.let { it + splitted[0] }
-    } else if (splitted.size == 2) {
-        val vocab = prefixMap[splitted[0]]
-        if (vocab == null) Timber.d("Prefix ${splitted[0]} has not been declared and is not a reserved prefix either.")
-        prefixMap[splitted[0]]?.let { it + splitted[1] }
-    } else // empty string
-        null
+    return if (splitted.size == 1 && defaultVocab != null) {
+        defaultVocab.iri + splitted[0]
+    } else if (splitted.size == 2 && prefixMap[splitted[0]] != null) {
+        prefixMap[splitted[0]] + splitted[1]
+    } else
+        property
 }
 
 internal fun parsePrefixes(prefixes: String): Map<String, String> =

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -362,7 +362,10 @@ class MetadataMiscTest {
     fun `otherMetadata is rightly filled`() {
         val otherMetadata = parsePackageDocument("package/meta-others.opf").metadata.otherMetadata
         assertThat(otherMetadata).contains(
-            entry(Vocabularies.DCTERMS + "source", "Wonderland"),
+            entry(
+                Vocabularies.DCTERMS + "source",
+                listOf("Feedbooks", mapOf("@value" to "Web", "http://my.url/#scheme" to "http"), "Internet")
+            ),
             entry(
                 "http://my.url/#property0", mapOf(
                     "@value" to "refines0",

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/PropertyDataTypeTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/PropertyDataTypeTest.kt
@@ -77,17 +77,6 @@ class TestResolveProperty {
         assertThat(resolveProperty("media:narrator", PACKAGE_RESERVED_PREFIXES, DEFAULT_VOCAB.META))
             .isEqualTo("http://www.idpf.org/epub/vocab/overlays/#narrator")
     }
-
-    @Test
-    fun `Return null when the prefix is unknown`() {
-        assertThat(resolveProperty("unknown:narrator", PACKAGE_RESERVED_PREFIXES, DEFAULT_VOCAB.META))
-            .isNull()
-    }
-
-    @Test
-    fun `Empty string is rightly handled`() {
-        assertThat(resolveProperty("", mapOf())).isNull()
-    }
 }
 
 class ParsePropertiesTest {

--- a/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/meta-others.opf
+++ b/r2-streamer/src/test/resources/org/readium/r2/streamer/parser/epub/package/meta-others.opf
@@ -2,7 +2,10 @@
 <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0" prefix="my: http://my.url/#">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:title>Alice's Adventures in Wonderland</dc:title>
-    <dc:source>Wonderland</dc:source>
+    <dc:source>Feedbooks</dc:source>
+    <meta id="source1" property="dcterms:source">Web</meta>
+    <meta refines="#source1" property="my:scheme">http</meta>
+    <meta name="dcterms:source" content="Internet"/>
     <meta id="r0" property="my:property0">refines0</meta>
     <meta id="r1" refines="r0" property="my:property1">refines1</meta>
     <meta id="r2" refines="r1" property="my:property2">refines2</meta>


### PR DESCRIPTION
By the way, resolve prefixes in old meta elements so that accessibility metadata can be uniformly handled in Epub 2.x and Epub 3.x.