### PR TITLE
Use ResourceInputStream in PublicationResourceHandler

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/PublicationResourceHandler.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/PublicationResourceHandler.kt
@@ -14,15 +14,18 @@ import org.nanohttpd.protocols.http.IHTTPSession
 import org.nanohttpd.protocols.http.NanoHTTPD.MIME_PLAINTEXT
 import org.nanohttpd.protocols.http.response.IStatus
 import org.nanohttpd.protocols.http.response.Response
+import org.nanohttpd.protocols.http.response.Response.newChunkedResponse
 import org.nanohttpd.protocols.http.response.Response.newFixedLengthResponse
 import org.nanohttpd.protocols.http.response.Status
 import org.nanohttpd.router.RouterNanoHTTPD
 import org.readium.r2.shared.fetcher.Resource
+import org.readium.r2.shared.fetcher.ResourceInputStream
 import org.readium.r2.shared.format.MediaType
 import org.readium.r2.streamer.BuildConfig.DEBUG
 import org.readium.r2.streamer.server.ServingFetcher
 import timber.log.Timber
 import java.io.IOException
+import java.io.InputStream
 
 
 class PublicationResourceHandler : RouterNanoHTTPD.DefaultHandler() {
@@ -39,89 +42,93 @@ class PublicationResourceHandler : RouterNanoHTTPD.DefaultHandler() {
         return Status.OK
     }
 
-    override fun get(uriResource: RouterNanoHTTPD.UriResource?, urlParams: Map<String, String>?,
-                     session: IHTTPSession?): Response? = runBlocking {
-        try {
-            if (DEBUG) Timber.v("Method: ${session!!.method}, Uri: ${session.uri}")
-            val fetcher = uriResource!!.initParameter(ServingFetcher::class.java)
+    override fun get(uriResource: RouterNanoHTTPD.UriResource, urlParams: Map<String, String>,
+                     session: IHTTPSession): Response = runBlocking {
 
-            val href = getHref(session!!)
-            fetcher.get(href).use { serveResponse(session, it) }
+        if (DEBUG) Timber.v("Method: ${session.method}, Uri: ${session.uri}")
+        val fetcher = uriResource.initParameter(ServingFetcher::class.java)
+
+        val href = getHref(session)
+        val resource = fetcher.get(href)
+
+        try {
+            serveResponse(session, resource)
         } catch(e: Resource.Error) {
+            Timber.e(e)
             responseFromFailure(e)
+                .also { resource.close() }
         } catch (e: Exception) {
             if (DEBUG) Timber.e(e)
             newFixedLengthResponse(Status.INTERNAL_ERROR, mimeType, ResponseStatus.FAILURE_RESPONSE)
+                .also { resource.close() }
         }
     }
 
     private suspend fun serveResponse(session: IHTTPSession, resource: Resource): Response {
-        var response: Response?
         var rangeRequest: String? = session.headers["range"]
         val mimeType = (resource.link().mediaType ?: MediaType.BINARY).toString()
 
-        try {
-            // Calculate etag
-            val etag = Integer.toHexString(resource.hashCode()) //FIXME: Is this working?
+        // Calculate etag
+        val etag = Integer.toHexString(resource.hashCode()) //FIXME: Is this working?
 
-            // Support skipping:
-            var startFrom: Long = 0
-            var endAt: Long = -1
-            if (rangeRequest != null) {
-                if (rangeRequest.startsWith("bytes=")) {
-                    rangeRequest = rangeRequest.substring("bytes=".length)
-                    val minus = rangeRequest.indexOf('-')
-                    try {
-                        if (minus > 0) {
-                            startFrom = java.lang.Long.parseLong(rangeRequest.substring(0, minus))
-                            endAt = java.lang.Long.parseLong(rangeRequest.substring(minus + 1))
-                        }
-                    } catch (ignored: NumberFormatException) {
+        // Support skipping:
+        var startFrom: Long = 0
+        var endAt: Long = -1
+        if (rangeRequest != null) {
+            if (rangeRequest.startsWith("bytes=")) {
+                rangeRequest = rangeRequest.substring("bytes=".length)
+                val minus = rangeRequest.indexOf('-')
+                try {
+                    if (minus > 0) {
+                        startFrom = java.lang.Long.parseLong(rangeRequest.substring(0, minus))
+                        endAt = java.lang.Long.parseLong(rangeRequest.substring(minus + 1))
                     }
-
+                } catch (ignored: NumberFormatException) {
                 }
+
             }
-
-            // Change return code and add Content-Range header when skipping is requested
-            val dataLength = resource.length().getOrThrow()
-
-            if (rangeRequest != null && startFrom >= 0) {
-                if (startFrom >= dataLength) {
-                    response = createResponse(Status.RANGE_NOT_SATISFIABLE, MIME_PLAINTEXT, "")
-                    response.addHeader("Content-Range", "bytes 0-0/$dataLength")
-                    response.addHeader("ETag", etag)
-                } else {
-                    if (endAt < 0) {
-                        endAt = dataLength - 1
-                    }
-
-                    val data = resource.read(startFrom..endAt).getOrThrow()
-                    response = createResponse(Status.PARTIAL_CONTENT, mimeType, data)
-                    response.addHeader("Content-Length", data.size.toString())
-                    response.addHeader("Content-Range", "bytes $startFrom-$endAt/$dataLength")
-                    response.addHeader("ETag", etag)
-                }
-            } else {
-                if (etag == session.headers["if-none-match"])
-                    response = createResponse(Status.NOT_MODIFIED, mimeType, "")
-                else {
-                    val data = resource.read().getOrThrow()
-                    response = createResponse(Status.OK, mimeType, data)
-                    response.addHeader("Content-Length", data.size.toString())
-                    response.addHeader("ETag", etag)
-                }
-            }
-        } catch (ioe: IOException) {
-            response = getResponse("Forbidden: Reading file failed")
-        } catch (ioe: NullPointerException) {
-            response = getResponse("Forbidden: Reading file failed")
         }
 
-        return response ?: getResponse("Error 404: File not found")
+        // Change return code and add Content-Range header when skipping is requested
+        return if (rangeRequest != null && startFrom >= 0) {
+            val dataLength = resource.length().getOrThrow()
+            if (endAt < 0) {
+                endAt = dataLength - 1
+            }
+
+            if (startFrom >= dataLength) {
+                createResponse(Status.RANGE_NOT_SATISFIABLE, MIME_PLAINTEXT, "")
+                    .apply {
+                        addHeader("Content-Range", "bytes 0-0/$dataLength")
+                        addHeader("ETag", etag)
+                    }.also {
+                       resource.close()
+                    }
+
+            } else {
+                createResponse(Status.PARTIAL_CONTENT, mimeType, ResourceInputStream(resource, startFrom..endAt))
+                    .apply {
+                        addHeader("Content-Range", "bytes 0-0/$dataLength")
+                        addHeader("ETag", etag)
+                    }
+            }
+        } else {
+            if (etag == session.headers["if-none-match"])
+                createResponse(Status.NOT_MODIFIED, mimeType, "")
+                    .also {
+                        resource.close()
+                    }
+            else {
+                createResponse(Status.OK, mimeType, ResourceInputStream(resource))
+                    .apply {
+                        addHeader("ETag", etag)
+                    }
+            }
+        }
     }
 
-    private fun createResponse(status: Status, mimeType: String, message: ByteArray): Response {
-        val response = newFixedLengthResponse(status, mimeType, message)
+    private fun createResponse(status: Status, mimeType: String, data: InputStream): Response {
+        val response = newChunkedResponse(status, mimeType, data)
         response.addHeader("Accept-Ranges", "bytes")
         return response
     }
@@ -130,10 +137,6 @@ class PublicationResourceHandler : RouterNanoHTTPD.DefaultHandler() {
         val response = newFixedLengthResponse(status, mimeType, message)
         response.addHeader("Accept-Ranges", "bytes")
         return response
-    }
-
-    private fun getResponse(message: String): Response {
-        return createResponse(Status.OK, "text/plain", message)
     }
 
     private fun getHref(session: IHTTPSession): String {

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/PublicationResourceHandler.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/PublicationResourceHandler.kt
@@ -65,6 +65,10 @@ class PublicationResourceHandler : RouterNanoHTTPD.DefaultHandler() {
     }
 
     private suspend fun serveResponse(session: IHTTPSession, resource: Resource): Response {
+        // Depending on the nature of the Response, either resource is closed here,
+        // or the responsibility of closing it is forwarded to the created ResourceInputStream.
+        // In the latter case, NanoHTTPd will close it at the end of the transmission.
+
         var rangeRequest: String? = session.headers["range"]
         val mimeType = (resource.link().mediaType ?: MediaType.BINARY).toString()
 


### PR DESCRIPTION
Fix a regression introduced in  #108 
When Webviews make big requests without consuming everything, we don't want to process and load the full range into the memory.