### PR TITLE
Replace File with PublicationAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 * Upgraded to Kotlin 1.4.10.
+* `Streamer` is now expecting a `PublicationAsset` instead of a `File`. You can create custom implementations of `PublicationAsset` to open a publication from different medium, such as a file, a remote URL, in-memory bytes, etc.
+  * `FileAsset` can be used to replace `File` and provides the same behavior.
 
 
 ## [2.0.0-alpha.2]

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/PublicationParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/PublicationParser.kt
@@ -7,29 +7,29 @@
 package org.readium.r2.streamer
 
 import org.readium.r2.shared.fetcher.Fetcher
-import org.readium.r2.shared.util.File
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.asset.PublicationAsset
 import org.readium.r2.shared.util.logging.WarningLogger
 
 /**
- *  Parses a Publication from a file.
+ *  Parses a Publication from an asset.
  */
 interface PublicationParser {
 
     /**
-     * Constructs a [Publication.Builder] to build a [Publication] from a publication file.
+     * Constructs a [Publication.Builder] to build a [Publication] from a publication asset.
      *
-     * @param file Path to the publication file.
+     * @param asset Digital medium (e.g. a file) used to access the publication.
      * @param fetcher Initial leaf fetcher which should be used to read the publication's resources.
      * This can be used to:
      * - support content protection technologies
      * - parse exploded archives or in archiving formats unknown to the parser, e.g. RAR
-     * If the file is not an archive, it will be reachable at the HREF /<file.name>,
+     * If the asset is not an archive, it will be reachable at the HREF /<asset.name>,
      * e.g. with a PDF.
      * @param warnings Used to report non-fatal parsing warnings, such as publication authoring
      * mistakes. This is useful to warn users of potential rendering issues or help authors
      * debug their publications.
      */
-    suspend fun parse(file: File, fetcher: Fetcher, warnings: WarningLogger? = null): Publication.Builder?
+    suspend fun parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger? = null): Publication.Builder?
 
 }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/Fetcher.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/Fetcher.kt
@@ -56,24 +56,6 @@ internal suspend fun Fetcher.Companion.fromArchiveOrDirectory(
     }
 }
 
-/** Creates a [Fetcher] from either a file or an exploded directory.
- *
- * Can throw SecurityException or FileNotFoundException.
- */
-internal suspend fun Fetcher.Companion.fromFile(
-    file: File,
-    archiveFactory: ArchiveFactory = DefaultArchiveFactory()
-): Fetcher =
-    when {
-        file.isDirectory ->
-            FileFetcher(href = "/", file = file)
-        file.exists() ->
-            ArchiveFetcher.fromPath(file.path, archiveFactory)
-                ?: FileFetcher(href = "/${file.name}", file = file)
-        else ->
-            throw FileNotFoundException(file.path)
-    }
-
 internal suspend fun Fetcher.guessTitle(): String? {
     val firstLink = links().firstOrNull() ?: return null
     val commonFirstComponent = links().hrefCommonFirstComponent() ?: return null
@@ -81,5 +63,5 @@ internal suspend fun Fetcher.guessTitle(): String? {
     if (commonFirstComponent.name == firstLink.href.removePrefix("/"))
        return null
 
-    return commonFirstComponent.toTitle()
+    return commonFirstComponent.name
 }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/File.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/File.kt
@@ -9,14 +9,11 @@
 
 package org.readium.r2.streamer.extensions
 
-import org.readium.r2.shared.util.File
+import java.io.File
 import java.util.Locale
 
-internal fun File.toTitle(): String =
-    file.nameWithoutExtension.replace("_", " ")
-
 internal val File.lowercasedExtension: String
-    get() = file.extension.toLowerCase(Locale.getDefault())
+    get() = extension.toLowerCase(Locale.getDefault())
 
 internal val File.isHiddenOrThumbs: Boolean
     get() = name.let { it.startsWith(".") || it == "Thumbs.db" }
@@ -26,6 +23,6 @@ internal val File.isHiddenOrThumbs: Boolean
  * regardless of whether it is a directory or a file.
  */
 internal val File.firstComponent: File
-    get() = file.parent.takeUnless { it == "/" }
+    get() = parent.takeUnless { it == "/" }
         ?.let { File(it).firstComponent }
         ?: this

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/Link.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/extensions/Link.kt
@@ -9,8 +9,8 @@
 
 package org.readium.r2.streamer.extensions
 
-import org.readium.r2.shared.util.File
 import org.readium.r2.shared.publication.Link
+import java.io.File
 
 
 /** Returns a [File] to the directory containing all links, if there is such a directory. */

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/cbz/CBZParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/cbz/CBZParser.kt
@@ -11,15 +11,16 @@ package org.readium.r2.streamer.parser.cbz
 
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.fetcher.Fetcher
-import org.readium.r2.shared.util.File
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.publication.*
+import org.readium.r2.shared.publication.asset.FileAsset
 import org.readium.r2.streamer.container.ContainerError
 import org.readium.r2.streamer.container.PublicationContainer
 import org.readium.r2.streamer.extensions.fromArchiveOrDirectory
 import org.readium.r2.streamer.parser.PubBox
 import org.readium.r2.streamer.parser.PublicationParser
 import org.readium.r2.streamer.parser.image.ImageParser
+import java.io.File
 
 @Deprecated("Use [MediaType] instead")
 class CBZConstant {
@@ -55,7 +56,7 @@ class CBZParser : PublicationParser {
         val fetcher = Fetcher.fromArchiveOrDirectory(fileAtPath)
             ?: throw ContainerError.missingFile(fileAtPath)
 
-        val publication = imageParser.parse(file, fetcher)
+        val publication = imageParser.parse(FileAsset(file), fetcher)
             ?.apply {
                 val title = LocalizedString(fallbackTitle)
                 val metadata =  manifest.metadata.copy(localizedTitle = title)
@@ -67,7 +68,7 @@ class CBZParser : PublicationParser {
 
         val container = PublicationContainer(
             publication = publication,
-            path = file.file.canonicalPath,
+            path = file.canonicalPath,
             mediaType = MediaType.CBZ
         )
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/pdf/PdfParser.kt
@@ -15,8 +15,9 @@ import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.fetcher.FileFetcher
 import org.readium.r2.shared.publication.*
+import org.readium.r2.shared.publication.asset.FileAsset
+import org.readium.r2.shared.publication.asset.PublicationAsset
 import org.readium.r2.shared.publication.services.InMemoryCoverService
-import org.readium.r2.shared.util.File
 import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.pdf.PdfDocumentFactory
@@ -24,8 +25,8 @@ import org.readium.r2.shared.util.pdf.toLinks
 import org.readium.r2.streamer.DefaultPdfDocumentFactory
 import org.readium.r2.streamer.PublicationParser
 import org.readium.r2.streamer.container.PublicationContainer
-import org.readium.r2.streamer.extensions.toTitle
 import org.readium.r2.streamer.parser.PubBox
+import java.io.File
 
 /**
  * Parses a PDF file into a Readium [Publication].
@@ -36,11 +37,11 @@ class PdfParser(
     private val pdfFactory: PdfDocumentFactory = DefaultPdfDocumentFactory(context)
 ) : PublicationParser, org.readium.r2.streamer.parser.PublicationParser {
 
-    override suspend fun parse(file: File, fetcher: Fetcher, warnings: WarningLogger?): Publication.Builder? =
-        _parse(file, fetcher, file.toTitle())
+    override suspend fun parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?): Publication.Builder? =
+        _parse(asset, fetcher, asset.name)
 
-    suspend fun _parse(file: File, fetcher: Fetcher, fallbackTitle: String): Publication.Builder? {
-        if (file.mediaType() != MediaType.PDF)
+    suspend fun _parse(asset: PublicationAsset, fetcher: Fetcher, fallbackTitle: String): Publication.Builder? {
+        if (asset.mediaType() != MediaType.PDF)
             return null
 
         val fileHref = fetcher.links().firstOrNull { it.mediaType == MediaType.PDF }?.href
@@ -50,7 +51,7 @@ class PdfParser(
 
         val manifest = Manifest(
             metadata = Metadata(
-                identifier = document.identifier ?: file.name,
+                identifier = document.identifier,
                 localizedTitle = LocalizedString(document.title?.ifBlank { null } ?: fallbackTitle),
                 authors = listOfNotNull(document.author).map { Contributor(name = it) },
                 numberOfPages = document.pageCount
@@ -70,9 +71,10 @@ class PdfParser(
     override fun parse(fileAtPath: String, fallbackTitle: String): PubBox? = runBlocking {
 
         val file = File(fileAtPath)
-        val baseFetcher = FileFetcher(href = "/${file.name}", file = file.file)
+        val asset = FileAsset(file)
+        val baseFetcher = FileFetcher(href = "/${file.name}", file = file)
         val builder = try {
-            _parse(file, baseFetcher, fallbackTitle)
+            _parse(asset, baseFetcher, fallbackTitle)
         } catch (e: Exception) {
             return@runBlocking null
         } ?: return@runBlocking null
@@ -80,10 +82,11 @@ class PdfParser(
         val publication = builder.build()
         val container = PublicationContainer(
             publication = publication,
-            path = file.file.canonicalPath,
+            path = file.canonicalPath,
             mediaType = MediaType.PDF
         )
 
         PubBox(publication, container)
     }
+
 }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
@@ -16,15 +16,14 @@ import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.drm.DRM
 import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.fetcher.TransformingFetcher
-import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.services.PerResourcePositionsService
 import org.readium.r2.shared.publication.services.locatorServiceFactory
 import org.readium.r2.shared.publication.services.positionsServiceFactory
 import org.readium.r2.shared.util.File
-
 import org.readium.r2.shared.util.logging.WarningLogger
+import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.pdf.PdfDocumentFactory
 import org.readium.r2.streamer.DefaultPdfDocumentFactory
 import org.readium.r2.streamer.PublicationParser
@@ -79,12 +78,6 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
         val readingOrder = manifest.readingOrder
         if (file.mediaType() == MediaType.LCP_PROTECTED_PDF && (readingOrder.isEmpty() || !readingOrder.all { it.mediaType.matches(MediaType.PDF) })) {
             throw Exception("Invalid LCP Protected PDF.")
-        }
-
-        val locatorService = when (file.mediaType()) {
-            MediaType.READIUM_AUDIOBOOK, MediaType.READIUM_AUDIOBOOK_MANIFEST, MediaType.LCP_PROTECTED_AUDIOBOOK ->
-                AudioLocatorService.createFactory()
-            else -> null
         }
 
         val servicesBuilder = Publication.ServicesBuilder().apply {

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/readium/ReadiumWebPubParser.kt
@@ -14,14 +14,17 @@ import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.readium.r2.shared.PdfSupport
 import org.readium.r2.shared.drm.DRM
+import org.readium.r2.shared.fetcher.ArchiveFetcher
 import org.readium.r2.shared.fetcher.Fetcher
+import org.readium.r2.shared.fetcher.FileFetcher
 import org.readium.r2.shared.fetcher.TransformingFetcher
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.asset.FileAsset
+import org.readium.r2.shared.publication.asset.PublicationAsset
 import org.readium.r2.shared.publication.services.PerResourcePositionsService
 import org.readium.r2.shared.publication.services.locatorServiceFactory
 import org.readium.r2.shared.publication.services.positionsServiceFactory
-import org.readium.r2.shared.util.File
 import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.pdf.PdfDocumentFactory
@@ -29,11 +32,11 @@ import org.readium.r2.streamer.DefaultPdfDocumentFactory
 import org.readium.r2.streamer.PublicationParser
 import org.readium.r2.streamer.container.ContainerError
 import org.readium.r2.streamer.container.PublicationContainer
-import org.readium.r2.streamer.extensions.fromFile
 import org.readium.r2.streamer.fetcher.LcpDecryptor
 import org.readium.r2.streamer.parser.PubBox
 import org.readium.r2.streamer.parser.audio.AudioLocatorService
 import org.readium.r2.streamer.toPublicationType
+import java.io.File
 import java.io.FileNotFoundException
 
 /**
@@ -45,16 +48,16 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
     constructor(context: Context) : this(pdfFactory = DefaultPdfDocumentFactory(context))
 
     override suspend fun parse(
-        file: File,
+        asset: PublicationAsset,
         fetcher: Fetcher,
         warnings: WarningLogger?
     ): Publication.Builder? {
 
-        if (!file.mediaType().isReadiumWebPubProfile)
+        if (!asset.mediaType().isReadiumWebPubProfile)
             return null
 
         val manifest =
-            if (file.mediaType().isRwpm) {
+            if (asset.mediaType().isRwpm) {
                 val manifestLink = fetcher.links().firstOrNull()
                     ?: error("Empty fetcher.")
                 val manifestJson = fetcher.get(manifestLink).use {
@@ -76,12 +79,12 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
         // Checks the requirements from the LCPDF specification.
         // https://readium.org/lcp-specs/notes/lcp-for-pdf.html
         val readingOrder = manifest.readingOrder
-        if (file.mediaType() == MediaType.LCP_PROTECTED_PDF && (readingOrder.isEmpty() || !readingOrder.all { it.mediaType.matches(MediaType.PDF) })) {
+        if (asset.mediaType() == MediaType.LCP_PROTECTED_PDF && (readingOrder.isEmpty() || !readingOrder.all { it.mediaType.matches(MediaType.PDF) })) {
             throw Exception("Invalid LCP Protected PDF.")
         }
 
         val servicesBuilder = Publication.ServicesBuilder().apply {
-            when (file.mediaType()) {
+            when (asset.mediaType()) {
                 MediaType.LCP_PROTECTED_PDF ->
                     positionsServiceFactory = pdfFactory?.let { LcpdfPositionsService.create(it) }
 
@@ -99,9 +102,10 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
     override fun parse(fileAtPath: String, fallbackTitle: String): PubBox? = runBlocking {
 
         val file = File(fileAtPath)
-        val mediaType = file.mediaType()
+        val asset = FileAsset(file)
+        val mediaType = asset.mediaType()
         var baseFetcher = try {
-            Fetcher.fromFile(file.file)
+            ArchiveFetcher.fromPath(file.path) ?: FileFetcher(href = "/${file.name}", file = file)
         } catch (e: SecurityException) {
             return@runBlocking null
         } catch (e: FileNotFoundException) {
@@ -114,7 +118,7 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
         }
 
         val builder = try {
-            parse(file, baseFetcher)
+            parse(asset, baseFetcher)
         } catch (e: Exception) {
             return@runBlocking null
         } ?: return@runBlocking null
@@ -124,7 +128,7 @@ class ReadiumWebPubParser(private val pdfFactory: PdfDocumentFactory? = null) : 
 
         val container = PublicationContainer(
             publication = publication,
-            path = file.file.canonicalPath,
+            path = file.canonicalPath,
             mediaType = mediaType,
             drm = drm
         ).apply {

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/TestUtils.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/TestUtils.kt
@@ -14,7 +14,7 @@ import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.fetcher.Resource
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.util.File
+import org.readium.r2.shared.publication.asset.PublicationAsset
 
 internal fun Resource.readBlocking(range: LongRange? = null) = runBlocking { read(range) }
 
@@ -28,5 +28,5 @@ internal fun Resource.linkBlocking(range: LongRange? = null) = runBlocking { lin
 
 internal fun Fetcher.linkBlocking(href: String) = runBlocking { get(Link(href = href)).use { it.linkBlocking() } }
 
-internal fun PublicationParser.parseBlocking(file: File, fetcher: Fetcher):
-        Publication.Builder? = runBlocking { parse(file, fetcher) }
+internal fun PublicationParser.parseBlocking(asset: PublicationAsset, fetcher: Fetcher):
+        Publication.Builder? = runBlocking { parse(asset, fetcher) }

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/extensions/FileTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/extensions/FileTest.kt
@@ -10,7 +10,7 @@
 package org.readium.r2.streamer.extensions
 
 import org.junit.Test
-import org.readium.r2.shared.util.File
+import java.io.File
 import kotlin.test.assertEquals
 
 class FileTest {


### PR DESCRIPTION
Depends on https://github.com/readium/r2-streamer-kotlin/pull/135
See https://github.com/readium/r2-shared-kotlin/pull/133

* `Streamer` is now expecting a `PublicationAsset` instead of a `File`. You can create custom implementations of `PublicationAsset` to open a publication from different medium, such as a file, a remote URL, in-memory bytes, etc.
  * `FileAsset` can be used to replace `File` and provides the same behavior.
