### PR TITLE
Disable text selection for protected EPUB publications

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -22,6 +22,7 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.epub.layoutOf
 import org.readium.r2.shared.publication.presentation.presentation
+import org.readium.r2.shared.publication.services.isProtected
 import org.readium.r2.streamer.parser.epub.ReadiumCssLayout
 import org.readium.r2.streamer.server.Resources
 import java.io.File
@@ -101,6 +102,19 @@ internal class HtmlInjector(
         }
         resourceHtml = StringBuilder(resourceHtml).insert(endHeadIndex, getHtmlFont(fontFamily = "OpenDyslexic", href = "/assets/fonts/OpenDyslexic-Regular.otf")).toString()
         resourceHtml = StringBuilder(resourceHtml).insert(endHeadIndex, "<style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>\n").toString()
+
+        // Disable the text selection if the publication is protected.
+        // FIXME: This is a hack until proper LCP copy is implemented, see https://github.com/readium/r2-testapp-kotlin/issues/266
+        if (publication.isProtected) {
+            resourceHtml = StringBuilder(resourceHtml).insert(endHeadIndex, """
+                <style>
+                *:not(input):not(textarea) {
+                    user-select: none;
+                    -webkit-user-select: none;
+                }
+                </style>
+            """).toString()
+        }
 
         // Inject userProperties
         getProperties(publication.userSettingsUIPreset)?.let { propertyPair ->


### PR DESCRIPTION
Disable text selection altogether if the publication is protected (with LCP or other). 

This is a hack until proper LCP copy is implemented, see https://github.com/readium/r2-testapp-kotlin/issues/266

Currently copy was unrestricted with LCP publications if an app didn't use the highlight feature. This is not apparent with highlighting because the standard popup is overridden and doesn't have the Copy option.

The downside at the moment is that highlighting is disabled with protected publication with this fix. This might be desirable or not, so we need to discuss this before merging this PR.

Note: This supersedes https://github.com/readium/r2-navigator-kotlin/pull/195 but this PR works in Chrome OS with user keyboard