### PR TITLE
Warnings cleanup and dependency updates

### DIFF
--- a/r2-streamer/build.gradle
+++ b/r2-streamer/build.gradle
@@ -48,7 +48,7 @@ dependencies {
         implementation "com.github.readium:r2-shared-kotlin:develop-SNAPSHOT"
     }
 
-    final JACKSON_VERSION = '2.12.1'
+    final JACKSON_VERSION = '2.12.2'
     implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-core:$JACKSON_VERSION"
@@ -72,17 +72,17 @@ dependencies {
         exclude module: 'support-v4'
     }
     implementation "joda-time:joda-time:2.10.10"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
 
     testImplementation "androidx.test.ext:junit-ktx:1.1.2"
     testImplementation "androidx.test:core-ktx:1.3.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation "net.sf.kxml:kxml2:2.3.0"
     testImplementation 'org.assertj:assertj-core:3.19.0'
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.4.31"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-    testImplementation "org.json:json:20200518"
+    testImplementation "org.json:json:20210307"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation "xmlpull:xmlpull:1.1.3.1"

--- a/r2-streamer/build.gradle
+++ b/r2-streamer/build.gradle
@@ -30,6 +30,7 @@ android {
     }
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        allWarningsAsErrors = true
     }
     buildTypes {
         release {
@@ -82,7 +83,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.4.31"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-    testImplementation "org.json:json:20210307"
+    // Latest version of org.json is incompatible with the one bundled in Android, breaking the tests.
+    //noinspection GradleDependency
+    testImplementation "org.json:json:20200518"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation "xmlpull:xmlpull:1.1.3.1"

--- a/r2-streamer/build.gradle
+++ b/r2-streamer/build.gradle
@@ -28,6 +28,9 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -46,7 +49,7 @@ dependencies {
     }
 
     final JACKSON_VERSION = '2.12.1'
-    implementation "androidx.appcompat:appcompat:1.3.0-beta01"
+    implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-core:$JACKSON_VERSION"
     implementation "com.fasterxml.jackson.core:jackson-databind:$JACKSON_VERSION"
@@ -68,7 +71,7 @@ dependencies {
     implementation("com.mcxiaoke.koi:async:0.5.5") {
         exclude module: 'support-v4'
     }
-    implementation "joda-time:joda-time:2.10.5"
+    implementation "joda-time:joda-time:2.10.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
 
     testImplementation "androidx.test.ext:junit-ktx:1.1.2"

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/Fetcher.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/Fetcher.kt
@@ -14,6 +14,8 @@ import org.readium.r2.streamer.container.Container
 import org.readium.r2.streamer.server.Resources
 import java.io.InputStream
 
+
+@Suppress("UNUSED_PARAMETER", "unused")
 @Deprecated("Use [publication.get(link)] to access publication content.", level = DeprecationLevel.ERROR)
 class Fetcher(var publication: Publication, var container: Container, private val userPropertiesPath: String?, customResources: Resources? = null) {
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -81,10 +81,9 @@ internal class HtmlInjector(
             // Inject all custom resourses
             for ((key, value) in it.resources) {
                 if (value is Pair<*, *>) {
-                    val res = value as Pair<String, String>
-                    if (Injectable(res.second) == Injectable.Script) {
+                    if (Injectable(value.second as String) == Injectable.Script) {
                         endIncludes.add(getHtmlScript("/${Injectable.Script.rawValue}/$key"))
-                    } else if (Injectable(res.second) == Injectable.Style) {
+                    } else if (Injectable(value.second as String) == Injectable.Style) {
                         endIncludes.add(getHtmlLink("/${Injectable.Style.rawValue}/$key"))
                     }
                 }

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/audio/AudioBookParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/audio/AudioBookParser.kt
@@ -40,10 +40,10 @@ class AudioBookParser : PublicationParser {
      * This functions parse a manifest.json and build PubBox object from it
      */
     override fun parse(fileAtPath: String, fallbackTitle: String): PubBox? = runBlocking {
-        _parse(fileAtPath, fallbackTitle)
+        _parse(fileAtPath)
     }
 
-    private suspend fun _parse(fileAtPath: String, fallbackTitle: String): PubBox? {
+    private suspend fun _parse(fileAtPath: String): PubBox? {
         val fetcher = Fetcher.fromArchiveOrDirectory(fileAtPath)
             ?: throw ContainerError.missingFile(fileAtPath)
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/divina/DiViNaParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/divina/DiViNaParser.kt
@@ -36,10 +36,10 @@ class DiViNaConstant {
  */
 class DiViNaParser : PublicationParser {
     override fun parse(fileAtPath: String, fallbackTitle: String): PubBox? = runBlocking {
-        _parse(fileAtPath, fallbackTitle)
+        _parse(fileAtPath)
     }
 
-    private suspend fun _parse(fileAtPath: String, fallbackTitle: String): PubBox? {
+    private suspend fun _parse(fileAtPath: String): PubBox? {
         val fetcher = Fetcher.fromArchiveOrDirectory(fileAtPath)
             ?: throw ContainerError.missingFile(fileAtPath)
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.ReadiumCSSName
 import org.readium.r2.shared.Search
 import org.readium.r2.shared.drm.DRM
+import org.readium.r2.shared.extensions.addPrefix
 import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.fetcher.TransformingFetcher
 import org.readium.r2.shared.publication.Link
@@ -89,7 +90,7 @@ class EpubParser : PublicationParser, org.readium.r2.streamer.parser.Publication
         if (asset.mediaType() != MediaType.EPUB)
             return null
 
-        val opfPath = getRootFilePath(fetcher)
+        val opfPath = getRootFilePath(fetcher).addPrefix("/")
         val opfXmlDocument = fetcher.get(opfPath).readAsXml().getOrThrow()
         val packageDocument = PackageDocument.parse(opfXmlDocument, opfPath)
             ?:  throw Exception("Invalid OPF file.")

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/server/Server.kt
@@ -147,10 +147,13 @@ abstract class AbstractServer(private var port: Int, private val context: Contex
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     @Deprecated("This is not needed anymore")
     fun loadReadiumCSSResources(assets: AssetManager) {}
+    @Suppress("UNUSED_PARAMETER")
     @Deprecated("This is not needed anymore")
     fun loadR2ScriptResources(assets: AssetManager) {}
+    @Suppress("UNUSED_PARAMETER")
     @Deprecated("This is not needed anymore")
     fun loadR2FontResources(assets: AssetManager, context: Context) {}
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/MediaOverlayHandler.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/server/handler/MediaOverlayHandler.kt
@@ -56,6 +56,7 @@ class MediaOverlayHandler : RouterNanoHTTPD.DefaultHandler() {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun getMediaOverlay(spines: List<Link>, searchQueryPath: String): MediaOverlays? {
         // FIXME: This is not supported until the model is properly specified
         return null

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/TestUtils.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/TestUtils.kt
@@ -12,22 +12,10 @@ package org.readium.r2.streamer
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.fetcher.Fetcher
 import org.readium.r2.shared.fetcher.Resource
-import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.asset.PublicationAsset
-import org.readium.r2.shared.util.use
 
 internal fun Resource.readBlocking(range: LongRange? = null) = runBlocking { read(range) }
-
-internal fun Fetcher.readBlocking(href: String) = runBlocking { get(Link(href = href)).use {  it.readBlocking() } }
-
-internal fun Resource.lengthBlocking(range: LongRange? = null) = runBlocking { length() }
-
-internal fun Fetcher.lengthBlocking(href: String) = runBlocking { get(Link(href = href)).use { it.lengthBlocking() } }
-
-internal fun Resource.linkBlocking(range: LongRange? = null) = runBlocking { link() }
-
-internal fun Fetcher.linkBlocking(href: String) = runBlocking { get(Link(href = href)).use { it.linkBlocking() } }
 
 internal fun PublicationParser.parseBlocking(asset: PublicationAsset, fetcher: Fetcher):
         Publication.Builder? = runBlocking { parse(asset, fetcher) }

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/EncryptionParserTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/EncryptionParserTest.kt
@@ -12,10 +12,13 @@ package org.readium.r2.streamer.parser.epub
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.readium.r2.shared.drm.DRM
 import org.readium.r2.shared.publication.encryption.Encryption
 import org.readium.r2.shared.parser.xml.XmlParser
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class EncryptionParserTest {
     fun parseEncryption(path: String): Map<String, Encryption> {
         val res = EncryptionParserTest::class.java.getResourceAsStream(path)

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/MetadataTest.kt
@@ -13,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.joda.time.DateTime
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.readium.r2.shared.publication.Collection
 import org.readium.r2.shared.publication.Contributor
 import org.readium.r2.shared.publication.LocalizedString
@@ -21,9 +22,11 @@ import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.firstWithRel
 import org.readium.r2.shared.publication.presentation.Presentation
 import org.readium.r2.shared.publication.presentation.presentation
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertNotNull
 import org.readium.r2.shared.publication.Link as SharedLink
 
+@RunWith(RobolectricTestRunner::class)
 class ContributorParsingTest {
     private val epub2Metadata = parsePackageDocument("package/contributors-epub2.opf").metadata
     private val epub3Metadata = parsePackageDocument("package/contributors-epub3.opf").metadata
@@ -172,6 +175,7 @@ class ContributorParsingTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class TitleTest {
     private val epub2Metadata = parsePackageDocument("package/titles-epub2.opf").metadata
     private val epub3Metadata = parsePackageDocument("package/titles-epub3.opf").metadata
@@ -226,6 +230,7 @@ class TitleTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class SubjectTest {
     private val complexMetadata = parsePackageDocument("package/subjects-complex.opf").metadata // epub3 only
 
@@ -278,6 +283,7 @@ class SubjectTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class DateTest {
     private val epub2Metadata = parsePackageDocument("package/dates-epub2.opf").metadata
     private val epub3Metadata = parsePackageDocument("package/dates-epub3.opf").metadata
@@ -297,6 +303,7 @@ class DateTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class MetadataMiscTest {
     @Test
     fun `Unique identifier is rightly parsed`() {
@@ -358,6 +365,7 @@ class MetadataMiscTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class CollectionTest {
     private val epub2Metadata = parsePackageDocument("package/collections-epub2.opf").metadata
     private val epub3Metadata = parsePackageDocument("package/collections-epub3.opf").metadata

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParserTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/NavigationDocumentParserTest.kt
@@ -12,16 +12,19 @@ package org.readium.r2.streamer.parser.epub
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.publication.Link
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertNotNull
 
+@RunWith(RobolectricTestRunner::class)
 class NavigationDocumentParserTest {
     private fun parseNavigationDocument(path: String): Map<String, List<Link>> {
         val res = NavigationDocumentParser::class.java.getResourceAsStream(path)
         checkNotNull(res)
         val document = XmlParser().parse(res)
-        val navigationDocument = NavigationDocumentParser.parse(document, "OEBPS/xhtml/nav.xhtml")
+        val navigationDocument = NavigationDocumentParser.parse(document, "/OEBPS/xhtml/nav.xhtml")
         assertNotNull(navigationDocument)
         return navigationDocument
     }
@@ -95,7 +98,7 @@ class NavigationDocumentParserTest {
 
     @Test
     fun `Fake Navigation Document is accepted`() {
-        Assertions.assertThat(navEmpty["toc"]).isNull()
+        assertThat(navEmpty["toc"]).isNull()
     }
 
     @Test

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/NcxParserTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/NcxParserTest.kt
@@ -11,10 +11,13 @@ package org.readium.r2.streamer.parser.epub
 
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.publication.Link
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertNotNull
 
+@RunWith(RobolectricTestRunner::class)
 class NcxParserTest {
     private fun parseNavigationDocument(path: String): Map<String, List<Link>> {
         val res = NcxParser::class.java.getResourceAsStream(path)

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/PackageDocumentTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/epub/PackageDocumentTest.kt
@@ -11,6 +11,7 @@ package org.readium.r2.streamer.parser.epub
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.readium.r2.shared.parser.xml.XmlParser
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Manifest
@@ -19,8 +20,9 @@ import org.readium.r2.shared.publication.epub.EpubLayout
 import org.readium.r2.shared.publication.epub.contains
 import org.readium.r2.shared.publication.epub.layout
 import org.readium.r2.shared.publication.presentation.*
+import org.robolectric.RobolectricTestRunner
 
-fun parsePackageDocument(path: String, displayOptions: String? = null): Manifest {
+fun parsePackageDocument(path: String): Manifest {
     val pub = PackageDocument::class.java.getResourceAsStream(path)
         ?.let { XmlParser().parse(it) }
         ?.let { PackageDocument.parse(it, "OEBPS/content.opf") }
@@ -32,6 +34,7 @@ fun parsePackageDocument(path: String, displayOptions: String? = null): Manifest
 
 const val PARSE_PUB_TIMEOUT = 1000L // milliseconds
 
+@RunWith(RobolectricTestRunner::class)
 class ReadingProgressionTest {
     @Test
     fun `No page progression direction is mapped to default`() {
@@ -58,6 +61,7 @@ class ReadingProgressionTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class LinkPropertyTest {
     private val propertiesPub = parsePackageDocument("package/links-properties.opf")
 
@@ -114,6 +118,7 @@ class LinkPropertyTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class LinkTest {
     private val resourcesPub = parsePackageDocument("package/links.opf")
 
@@ -176,6 +181,7 @@ class LinkTest {
     }
 }
 
+@RunWith(RobolectricTestRunner::class)
 class LinkMiscTest {
     fun `Fallbacks are mapped to alternates`() {
         assertThat(parsePackageDocument("package/fallbacks.opf")).isEqualTo(


### PR DESCRIPTION
Cleaned up warnings by doing the following: 

* Replaced deprecated code
* Annotated unused parameters for deprecated functions
* Removed unused parameters from non-deprecated functions
* Added `freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"` to kotlinOptions
* Modified functions with type cast warnings

Dependencies were also updated.