### PR TITLE
Fix EPUB style injection when the <head> tag is not on its own line

### DIFF
--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -53,10 +53,10 @@ internal class HtmlInjector(
 
     }
 
-    private fun injectReflowableHtml(content: String): String {
+    internal fun injectReflowableHtml(content: String): String {
         var resourceHtml = content
         // Inject links to css and js files
-        val head = Regex("""<head.*>""").find(resourceHtml, 0)
+        val head = Regex("""<head.*?>""").find(resourceHtml, 0)
         if (head == null) {
             Timber.e("No <head> tag found in this resource")
             return resourceHtml
@@ -116,14 +116,14 @@ internal class HtmlInjector(
 
         // Inject userProperties
         getProperties(publication.userSettingsUIPreset)?.let { propertyPair ->
-            val html = Regex("""<html.*>""").find(resourceHtml, 0)
+            val html = Regex("""<html.*?>""").find(resourceHtml, 0)
             html?.let {
                 val match = Regex("""(style=("([^"]*)"[ >]))|(style='([^']*)'[ >])""").find(html.value, 0)
                 if (match != null) {
                     val beginStyle = match.range.first + 7
                     var newHtml = html.value
                     newHtml = StringBuilder(newHtml).insert(beginStyle, "${buildStringProperties(propertyPair)} ").toString()
-                    resourceHtml = StringBuilder(resourceHtml).replace(Regex("""<html.*>"""), newHtml)
+                    resourceHtml = StringBuilder(resourceHtml).replace(Regex("""<html.*?>"""), newHtml)
                 } else {
                     val beginHtmlIndex = resourceHtml.indexOf("<html", 0, false) + 5
                     resourceHtml = StringBuilder(resourceHtml).insert(beginHtmlIndex, " style=\"${buildStringProperties(propertyPair)}\"").toString()
@@ -142,7 +142,7 @@ internal class HtmlInjector(
     private fun applyDirectionAttribute(resourceHtml: String, publication: Publication): String {
         var resourceHtml1 = resourceHtml
         fun addRTLDir(tagName: String, html: String): String {
-            return Regex("""<$tagName.*>""").find(html, 0)?.let { result ->
+            return Regex("""<$tagName.*?>""").find(html, 0)?.let { result ->
                 Regex("""dir=""").find(result.value, 0)?.let {
                     html
                 } ?: run {

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -56,13 +56,13 @@ internal class HtmlInjector(
     internal fun injectReflowableHtml(content: String): String {
         var resourceHtml = content
         // Inject links to css and js files
-        val head = Regex("""<head.*?>""").find(resourceHtml, 0)
+        val head = regexForOpeningHTMLTag("head").find(resourceHtml, 0)
         if (head == null) {
             Timber.e("No <head> tag found in this resource")
             return resourceHtml
         }
         var beginHeadIndex = head.range.last + 1
-        var endHeadIndex = resourceHtml.indexOf("</head>", 0, false)
+        var endHeadIndex = resourceHtml.indexOf("</head>", 0, true)
         if (endHeadIndex == -1)
             return content
 
@@ -116,20 +116,20 @@ internal class HtmlInjector(
 
         // Inject userProperties
         getProperties(publication.userSettingsUIPreset)?.let { propertyPair ->
-            val html = Regex("""<html.*?>""").find(resourceHtml, 0)
+            val html = regexForOpeningHTMLTag("html").find(resourceHtml, 0)
             html?.let {
                 val match = Regex("""(style=("([^"]*)"[ >]))|(style='([^']*)'[ >])""").find(html.value, 0)
                 if (match != null) {
                     val beginStyle = match.range.first + 7
                     var newHtml = html.value
                     newHtml = StringBuilder(newHtml).insert(beginStyle, "${buildStringProperties(propertyPair)} ").toString()
-                    resourceHtml = StringBuilder(resourceHtml).replace(Regex("""<html.*?>"""), newHtml)
+                    resourceHtml = StringBuilder(resourceHtml).replace(regexForOpeningHTMLTag("html"), newHtml)
                 } else {
-                    val beginHtmlIndex = resourceHtml.indexOf("<html", 0, false) + 5
+                    val beginHtmlIndex = resourceHtml.indexOf("<html", 0, true) + 5
                     resourceHtml = StringBuilder(resourceHtml).insert(beginHtmlIndex, " style=\"${buildStringProperties(propertyPair)}\"").toString()
                 }
             } ?:run {
-                val beginHtmlIndex = resourceHtml.indexOf("<html", 0, false) + 5
+                val beginHtmlIndex = resourceHtml.indexOf("<html", 0, true) + 5
                 resourceHtml = StringBuilder(resourceHtml).insert(beginHtmlIndex, " style=\"${buildStringProperties(propertyPair)}\"").toString()
             }
         }
@@ -142,11 +142,11 @@ internal class HtmlInjector(
     private fun applyDirectionAttribute(resourceHtml: String, publication: Publication): String {
         var resourceHtml1 = resourceHtml
         fun addRTLDir(tagName: String, html: String): String {
-            return Regex("""<$tagName.*?>""").find(html, 0)?.let { result ->
+            return regexForOpeningHTMLTag(tagName).find(html, 0)?.let { result ->
                 Regex("""dir=""").find(result.value, 0)?.let {
                     html
                 } ?: run {
-                    val beginHtmlIndex = html.indexOf("<$tagName", 0, false) + 5
+                    val beginHtmlIndex = html.indexOf("<$tagName", 0, true) + 5
                     StringBuilder(html).insert(beginHtmlIndex, " dir=\"rtl\"").toString()
                 }
             } ?: run {
@@ -162,9 +162,12 @@ internal class HtmlInjector(
         return resourceHtml1
     }
 
+    private fun regexForOpeningHTMLTag(name: String): Regex =
+        Regex("""<$name.*?>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+
     private fun injectFixedLayoutHtml(content: String): String {
         var resourceHtml = content
-        val endHeadIndex = resourceHtml.indexOf("</head>", 0, false)
+        val endHeadIndex = resourceHtml.indexOf("</head>", 0, true)
         if (endHeadIndex == -1)
             return content
         val includes = mutableListOf<String>()

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/fetcher/HtmlInjector.kt
@@ -53,7 +53,7 @@ internal class HtmlInjector(
 
     }
 
-    internal fun injectReflowableHtml(content: String): String {
+    private fun injectReflowableHtml(content: String): String {
         var resourceHtml = content
         // Inject links to css and js files
         val head = regexForOpeningHTMLTag("head").find(resourceHtml, 0)

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
@@ -1,0 +1,102 @@
+package org.readium.r2.streamer.fetcher
+
+import org.junit.Test
+import org.readium.r2.shared.publication.LocalizedString
+import org.readium.r2.shared.publication.Manifest
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.Publication
+import kotlin.test.assertEquals
+
+class HtmlInjectorTest {
+
+    private val sut = HtmlInjector(
+        publication = Publication(manifest = Manifest(metadata = Metadata(localizedTitle = LocalizedString("")))),
+        userPropertiesPath = null
+    )
+
+    @Test
+    fun `Inject a reflowable with a simple HEAD`() {
+        assertEquals(
+            """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                    <head><meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
+
+                        <title>Publication</title>
+                        <link rel="stylesheet" href="style.css" type="text/css"/>
+                    <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
+                <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
+                <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
+                </head>
+                    <body></body>
+                </html>
+            """.trimIndent(),
+            sut.injectReflowableHtml("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                    <head>
+                        <title>Publication</title>
+                        <link rel="stylesheet" href="style.css" type="text/css"/>
+                    </head>
+                    <body></body>
+                </html>
+            """.trimIndent())
+        )
+    }
+
+    @Test
+    fun `Inject a reflowable with a HEAD with attributes`() {
+        assertEquals(
+            """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                    <head xmlns:xlink="http://www.w3.org/1999/xlink"><meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
+
+                        <title>Publication</title>
+                        <link rel="stylesheet" href="style.css" type="text/css"/>
+                    <link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
+                <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
+                <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
+                </head>
+                    <body></body>
+                </html>
+            """.trimIndent(),
+            sut.injectReflowableHtml("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                    <head xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title>Publication</title>
+                        <link rel="stylesheet" href="style.css" type="text/css"/>
+                    </head>
+                    <body></body>
+                </html>
+            """.trimIndent())
+        )
+    }
+
+    @Test
+    fun `Inject a reflowable with HEAD with attributes on a single line`() {
+        assertEquals(
+            """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head xmlns:xlink="http://www.w3.org/1999/xlink"><meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
+                <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
+                <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
+                <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
+                </head><body></body></html>
+            """.trimIndent(),
+            sut.injectReflowableHtml("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head xmlns:xlink="http://www.w3.org/1999/xlink"><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/></head><body></body></html>
+            """.trimIndent())
+        )
+    }
+
+}

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
@@ -1,18 +1,12 @@
 package org.readium.r2.streamer.fetcher
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
-import org.readium.r2.shared.publication.LocalizedString
-import org.readium.r2.shared.publication.Manifest
-import org.readium.r2.shared.publication.Metadata
-import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.fetcher.StringResource
+import org.readium.r2.shared.publication.*
 import kotlin.test.assertEquals
 
 class HtmlInjectorTest {
-
-    private val sut = HtmlInjector(
-        publication = Publication(manifest = Manifest(metadata = Metadata(localizedTitle = LocalizedString("")))),
-        userPropertiesPath = null
-    )
 
     @Test
     fun `Inject a reflowable with a simple HEAD`() {
@@ -33,7 +27,7 @@ class HtmlInjectorTest {
                     <body></body>
                 </html>
             """.trimIndent(),
-            sut.injectReflowableHtml("""
+            transform("""
                 <?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -66,7 +60,7 @@ class HtmlInjectorTest {
                     <body></body>
                 </html>
             """.trimIndent(),
-            sut.injectReflowableHtml("""
+            transform("""
                 <?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
                 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -92,7 +86,7 @@ class HtmlInjectorTest {
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
                 </head><body></body></html>
             """.trimIndent(),
-            sut.injectReflowableHtml("""
+            transform("""
                 <?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head xmlns:xlink="http://www.w3.org/1999/xlink"><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/></head><body></body></html>
             """.trimIndent())
@@ -113,13 +107,27 @@ class HtmlInjectorTest {
                 <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
                 </HEAD><body></body></html>
             """.trimIndent(),
-            sut.injectReflowableHtml("""
+            transform("""
                 <?xml version="1.0" encoding="utf-8"?>
                 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><HEAD
                  xmlns:xlink="http://www.w3.org/1999/xlink"
                  ><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/></HEAD><body></body></html>
             """.trimIndent())
         )
+    }
+
+    private fun transform(content: String): String = runBlocking {
+        val sut = HtmlInjector(
+            publication = Publication(manifest = Manifest(metadata = Metadata(localizedTitle = LocalizedString("")))),
+            userPropertiesPath = null
+        )
+
+        val link = Link(href = "", type = "application/xhtml+xml")
+
+        sut
+            .transform(StringResource(link, content))
+            .readAsString()
+            .getOrThrow()
     }
 
 }

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/fetcher/HtmlInjectorTest.kt
@@ -99,4 +99,27 @@ class HtmlInjectorTest {
         )
     }
 
+    @Test
+    fun `Inject a reflowable with uppercase HEAD with attributes on several lines`() {
+        assertEquals(
+            """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><HEAD
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 ><meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-before.css"/>
+                <title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/><link rel="stylesheet" type="text/css" href="/assets/readium-css/ReadiumCSS-after.css"/>
+                <script type="text/javascript" src="/assets/scripts/readium-reflowable.js"></script>
+                <style>@import url('https://fonts.googleapis.com/css?family=PT+Serif|Roboto|Source+Sans+Pro|Vollkorn');</style>
+                <style type="text/css"> @font-face{font-family: "OpenDyslexic"; src:url("/assets/fonts/OpenDyslexic-Regular.otf") format('truetype');}</style>
+                </HEAD><body></body></html>
+            """.trimIndent(),
+            sut.injectReflowableHtml("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><HEAD
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 ><title>Publication</title><link rel="stylesheet" href="style.css" type="text/css"/></HEAD><body></body></html>
+            """.trimIndent())
+        )
+    }
+
 }


### PR DESCRIPTION
The regex to match the `head` tag was too greedy.
For example, if the `<head>` tag was on the same line as another tag, e.g. `<head><style></style>`, then everything would be matched until the last `>` occurrence.

Regression introduced in https://github.com/readium/r2-streamer-kotlin/pull/155.