### PR TITLE
Add a fallback ContentProtection implementation for known DRM schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * EPUB publications implement a `SearchService` to search through the content.
+* Known DRM schemes (LCP and Adobe ADEPT) are now sniffed by the `Streamer`, when no registered `ContentProtection` supports them.
+    * This is helpful to present an error message when the user attempts to open a protected publication not supported by the app.
 
 ### Changed
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/Streamer.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/Streamer.kt
@@ -22,6 +22,7 @@ import org.readium.r2.shared.util.http.DefaultHttpClient
 import org.readium.r2.shared.util.logging.WarningLogger
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.pdf.PdfDocumentFactory
+import org.readium.r2.streamer.parser.FallbackContentProtection
 import org.readium.r2.streamer.parser.audio.AudioParser
 import org.readium.r2.streamer.parser.epub.EpubParser
 import org.readium.r2.streamer.parser.epub.setLayoutStyle
@@ -29,7 +30,6 @@ import org.readium.r2.streamer.parser.image.ImageParser
 import org.readium.r2.streamer.parser.pdf.PdfParser
 import org.readium.r2.streamer.parser.pdf.PdfiumPdfDocumentFactory
 import org.readium.r2.streamer.parser.readium.ReadiumWebPubParser
-import kotlin.Exception
 
 internal typealias PublicationTry<SuccessT> = Try<SuccessT, Publication.OpeningException>
 
@@ -55,12 +55,15 @@ class Streamer constructor(
     context: Context,
     parsers: List<PublicationParser> = emptyList(),
     ignoreDefaultParsers: Boolean = false,
-    private val contentProtections: List<ContentProtection> = emptyList(),
+    contentProtections: List<ContentProtection> = emptyList(),
     private val archiveFactory: ArchiveFactory = DefaultArchiveFactory(),
     private val pdfFactory: PdfDocumentFactory = DefaultPdfDocumentFactory(context),
     private val httpClient: DefaultHttpClient = DefaultHttpClient(),
     private val onCreatePublication: Publication.Builder.() -> Unit = {}
 ) {
+
+    private val contentProtections: List<ContentProtection> =
+        contentProtections + listOf(FallbackContentProtection())
 
     /**
      * Parses a [Publication] from the given asset.

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/FallbackContentProtection.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/FallbackContentProtection.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.streamer.parser
+
+import org.readium.r2.shared.UserException
+import org.readium.r2.shared.fetcher.Fetcher
+import org.readium.r2.shared.publication.ContentProtection
+import org.readium.r2.shared.publication.ContentProtection.Scheme
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.asset.PublicationAsset
+import org.readium.r2.shared.publication.services.ContentProtectionService
+import org.readium.r2.shared.publication.services.contentProtectionServiceFactory
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.readium.r2.streamer.extensions.readAsJsonOrNull
+import org.readium.r2.streamer.extensions.readAsXmlOrNull
+import org.readium.r2.streamer.parser.epub.EncryptionParser
+
+/**
+ * [ContentProtection] implementation used as a fallback by the Streamer to detect known DRM
+ * schemes (e.g. LCP or ADEPT), if they are not supported by the app.
+ */
+internal class FallbackContentProtection : ContentProtection {
+
+    class Service(override val scheme: Scheme?) : ContentProtectionService {
+
+        override val isRestricted: Boolean = true
+        override val credentials: String? = null
+        override val rights = ContentProtectionService.UserRights.AllRestricted
+        override val error: UserException = ContentProtection.Exception.SchemeNotSupported(scheme)
+
+        companion object {
+
+            fun createFactory(scheme: Scheme?): (Publication.Service.Context) -> Service =
+                { Service(scheme) }
+        }
+
+    }
+
+    override suspend fun open(
+        asset: PublicationAsset,
+        fetcher: Fetcher,
+        credentials: String?,
+        allowUserInteraction: Boolean,
+        sender: Any?
+    ): Try<ContentProtection.ProtectedAsset, Publication.OpeningException>? {
+        val scheme: Scheme = sniffScheme(fetcher, asset.mediaType())
+            ?: return null
+
+        val protectedFile = ContentProtection.ProtectedAsset(
+            asset = asset,
+            fetcher = fetcher,
+            onCreatePublication = {
+                servicesBuilder.contentProtectionServiceFactory = Service.createFactory(scheme)
+            }
+        )
+
+        return Try.success(protectedFile)
+    }
+
+    internal suspend fun sniffScheme(fetcher: Fetcher, mediaType: MediaType): Scheme? =
+        when {
+            fetcher.readAsJsonOrNull("/license.lcpl") != null ->
+                Scheme.Lcp
+
+            mediaType.matches(MediaType.EPUB) -> {
+                val encryption = fetcher.readAsXmlOrNull("/META-INF/encryption.xml")
+                    ?.let { EncryptionParser.parse(it) }
+                val rights = fetcher.readAsXmlOrNull("/META-INF/rights.xml")
+
+                when {
+                    (
+                        fetcher.readAsJsonOrNull("/META-INF/license.lcpl") != null ||
+                        encryption?.any { it.value.scheme == "http://readium.org/2014/01/lcp" } == true
+                    ) -> Scheme.Lcp
+
+                    (
+                        encryption != null &&
+                        rights?.namespace == "http://ns.adobe.com/adept"
+                    ) -> Scheme.Adept
+
+                    // A file with only obfuscated fonts might still have an `encryption.xml` file.
+                    // To make sure that we don't lock a readable publication, we ignore unknown
+                    // encryption.xml schemes.
+                    else -> null
+                }
+            }
+
+            else -> null
+        }
+}

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/FallbackContentProtectionTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/FallbackContentProtectionTest.kt
@@ -79,6 +79,26 @@ class FallbackContentProtectionTest {
         assertEquals(Scheme.Adept, sniff(
             mediaType = MediaType.EPUB,
             resources = mapOf(
+                "/META-INF/encryption.xml" to """<?xml version="1.0"?><encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#">
+    <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"></EncryptionMethod>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <resource xmlns="http://ns.adobe.com/adept">urn:uuid:2c43729c-b985-4531-8e86-ae75ce5e5da9</resource>
+    </KeyInfo>
+    <CipherData>
+      <CipherReference URI="OEBPS/stylesheet.css"></CipherReference>
+    </CipherData>
+  </EncryptedData>
+  </encryption>"""
+            )
+        ))
+    }
+
+    @Test
+    fun `Sniff Adobe ADEPT from rights xml`() {
+        assertEquals(Scheme.Adept, sniff(
+            mediaType = MediaType.EPUB,
+            resources = mapOf(
                 "/META-INF/encryption.xml" to """<?xml version='1.0' encoding='utf-8'?><encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#"></encryption>""",
                 "/META-INF/rights.xml" to """<?xml version="1.0"?><adept:rights xmlns:adept="http://ns.adobe.com/adept"></adept:rights>"""
             )

--- a/r2-streamer/src/test/java/org/readium/r2/streamer/parser/FallbackContentProtectionTest.kt
+++ b/r2-streamer/src/test/java/org/readium/r2/streamer/parser/FallbackContentProtectionTest.kt
@@ -1,0 +1,105 @@
+package org.readium.r2.streamer.parser
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.fetcher.FailureResource
+import org.readium.r2.shared.fetcher.Fetcher
+import org.readium.r2.shared.fetcher.Resource
+import org.readium.r2.shared.fetcher.StringResource
+import org.readium.r2.shared.publication.ContentProtection.Scheme
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FallbackContentProtectionTest {
+
+    @Test
+    fun `Sniff no content protection`() {
+        assertNull(sniff(mediaType = MediaType.EPUB, resources = emptyMap()))
+    }
+
+    @Test
+    fun `Sniff EPUB with empty encryption xml`() {
+        assertNull(sniff(mediaType = MediaType.EPUB, resources = mapOf(
+            "/META-INF/encryption.xml" to """<?xml version='1.0' encoding='utf-8'?><encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#"></encryption>"""
+        )))
+    }
+
+    @Test
+    fun `Sniff LCP protected package`() {
+        assertEquals(Scheme.Lcp, sniff(
+            mediaType = MediaType.ZIP,
+            resources = mapOf(
+                "/license.lcpl" to "{}"
+            )
+        ))
+    }
+
+    @Test
+    fun `Sniff LCP protected EPUB`() {
+        assertEquals(Scheme.Lcp, sniff(
+            mediaType = MediaType.EPUB,
+            resources = mapOf(
+                "/META-INF/license.lcpl" to "{}"
+            )
+        ))
+    }
+
+    @Test
+    fun `Sniff LCP protected EPUB missing the license`() {
+        assertEquals(Scheme.Lcp, sniff(
+            mediaType = MediaType.EPUB,
+            resources = mapOf(
+                "/META-INF/encryption.xml" to """<?xml version="1.0" encoding="UTF-8"?>
+<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#">
+    <EncryptionMethod xmlns="http://www.w3.org/2001/04/xmlenc#" Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"></EncryptionMethod>
+    <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <RetrievalMethod xmlns="http://www.w3.org/2000/09/xmldsig#" URI="license.lcpl#/encryption/content_key" Type="http://readium.org/2014/01/lcp#EncryptedContentKey"></RetrievalMethod>
+    </KeyInfo>
+    <CipherData xmlns="http://www.w3.org/2001/04/xmlenc#">
+      <CipherReference xmlns="http://www.w3.org/2001/04/xmlenc#" URI="OPS/chapter_001.xhtml"></CipherReference>
+    </CipherData>
+    <EncryptionProperties xmlns="http://www.w3.org/2001/04/xmlenc#">
+      <EncryptionProperty xmlns="http://www.w3.org/2001/04/xmlenc#">
+        <Compression xmlns="http://www.idpf.org/2016/encryption#compression" Method="8" OriginalLength="13877"></Compression>
+      </EncryptionProperty>
+    </EncryptionProperties>
+  </EncryptedData>
+</encryption>"""
+            )
+        ))
+    }
+
+    @Test
+    fun `Sniff Adobe ADEPT`() {
+        assertEquals(Scheme.Adept, sniff(
+            mediaType = MediaType.EPUB,
+            resources = mapOf(
+                "/META-INF/encryption.xml" to """<?xml version='1.0' encoding='utf-8'?><encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#"></encryption>""",
+                "/META-INF/rights.xml" to """<?xml version="1.0"?><adept:rights xmlns:adept="http://ns.adobe.com/adept"></adept:rights>"""
+            )
+        ))
+    }
+
+    private fun sniff(mediaType: MediaType, resources: Map<String, String>): Scheme? = runBlocking {
+        FallbackContentProtection().sniffScheme(
+            fetcher = TestFetcher(resources),
+            mediaType = mediaType
+        )
+    }
+}
+
+class TestFetcher(private val resources: Map<String, String> = emptyMap()) : Fetcher {
+
+    override suspend fun links(): List<Link> = resources.map { Link(href = it.key) }
+
+    override fun get(link: Link): Resource =
+        resources[link.href]?.let { StringResource(link, it) }
+            ?: FailureResource(link, Resource.Exception.NotFound())
+
+    override suspend fun close() {}
+}


### PR DESCRIPTION
### Added

* Known DRM schemes (LCP and Adobe ADEPT) are now sniffed by the `Streamer`, when no registered `ContentProtection` supports them.
    * This is helpful to present an error message when the user attempts to open a protected publication not supported by the app.

Depends on https://github.com/readium/r2-shared-kotlin/pull/168