### PR TITLE
Use archive entry length instead of original length for EPUB positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * Upgraded to Kotlin 1.5.21 and Gradle 7.1.1
+* The default EPUB positions service now uses the archive entry length when available. [This is similar to how Adobe RMSDK generates page numbers](https://github.com/readium/architecture/issues/123).
+    * To use the former strategy, create the `Streamer` with: `Streamer(parsers = listOf(EpubParser(reflowablePositionsStrategy = OriginalLength(pageLength = 1024))))`
 
 ### Fixed
 

--- a/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
+++ b/r2-streamer/src/main/java/org/readium/r2/streamer/parser/epub/EpubParser.kt
@@ -78,8 +78,13 @@ object EPUBConstant {
 
 /**
  * Parses a Publication from an EPUB publication.
+ *
+ * @param reflowablePositionsStrategy Strategy used to calculate the number of positions in a
+ *        reflowable resource.
  */
-class EpubParser : PublicationParser, org.readium.r2.streamer.parser.PublicationParser {
+class EpubParser(
+    private val reflowablePositionsStrategy: EpubPositionsService.ReflowableStrategy = EpubPositionsService.ReflowableStrategy.recommended
+) : PublicationParser, org.readium.r2.streamer.parser.PublicationParser {
 
     override suspend fun parse(asset: PublicationAsset, fetcher: Fetcher, warnings: WarningLogger?): Publication.Builder? =
         _parse(asset, fetcher, asset.name)
@@ -113,7 +118,7 @@ class EpubParser : PublicationParser, org.readium.r2.streamer.parser.Publication
             manifest = manifest,
             fetcher = fetcher,
             servicesBuilder = Publication.ServicesBuilder(
-                positions = (EpubPositionsService)::create,
+                positions = EpubPositionsService.createFactory(reflowablePositionsStrategy),
                 search = StringSearchService.createDefaultFactory(),
             )
         )


### PR DESCRIPTION
### Changed

* The default EPUB positions service now uses the archive entry length when available. [This is similar to how Adobe RMSDK generates page numbers](https://github.com/readium/architecture/issues/123).
    * To use the former strategy, create the `Streamer` with: `Streamer(parsers = listOf(EpubParser(reflowablePositionsStrategy = OriginalLength(pageLength = 1024))))`

Depends on https://github.com/readium/r2-shared-kotlin/pull/169
Port of https://github.com/readium/r2-streamer-swift/pull/209